### PR TITLE
Disable publishing to MyGet

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -11,6 +11,7 @@ BuildParameters.SetParameters(
     repositoryName: "Cake.Issues.InspectCode",
     appVeyorAccountName: "cakecontrib",
     shouldGenerateDocumentation: false,
+    shouldPublishMyGet: false,
     shouldRunCodecov: false,
     shouldRunGitVersion: true);
 


### PR DESCRIPTION
Disable publishing of NuGet packages to MyGet, since we run out of quota. Once Cake.Recipe 2.0.0 is available we can enable publishing of CI package to GitHub.