### PR TITLE
(GH-189) Multi-Target .NET Core 3.1, 5 & 6 instead of .NET Standard 2.0

### DIFF
--- a/nuspec/nuget/Cake.Issues.InspectCode.nuspec
+++ b/nuspec/nuget/Cake.Issues.InspectCode.nuspec
@@ -28,11 +28,14 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net461/Cake.Issues.InspectCode.dll" target="lib\net461" />
-    <file src="net461/Cake.Issues.InspectCode.pdb" target="lib\net461" />
-    <file src="net461/Cake.Issues.InspectCode.xml" target="lib\net461" />
-    <file src="netstandard2.0/Cake.Issues.InspectCode.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0/Cake.Issues.InspectCode.pdb" target="lib\netstandard2.0" />
-    <file src="netstandard2.0/Cake.Issues.InspectCode.xml" target="lib\netstandard2.0" />
+    <file src="netcoreapp3.1/Cake.Issues.InspectCode.dll" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1/Cake.Issues.InspectCode.pdb" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1/Cake.Issues.InspectCode.xml" target="lib\netcoreapp3.1" />
+    <file src="net5.0/Cake.Issues.InspectCode.dll" target="lib\net5.0" />
+    <file src="net5.0/Cake.Issues.InspectCode.pdb" target="lib\net5.0" />
+    <file src="net5.0/Cake.Issues.InspectCode.xml" target="lib\net5.0" />
+    <file src="net6.0/Cake.Issues.InspectCode.dll" target="lib\net6.0" />
+    <file src="net6.0/Cake.Issues.InspectCode.pdb" target="lib\net6.0" />
+    <file src="net6.0/Cake.Issues.InspectCode.xml" target="lib\net6.0" />
   </files>
 </package>

--- a/src/Cake.Issues.InspectCode.Tests/Cake.Issues.InspectCode.Tests.csproj
+++ b/src/Cake.Issues.InspectCode.Tests/Cake.Issues.InspectCode.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Product>Cake.Issues</Product>
     <Description>Tests for the Cake.Issues.InspectCode addin</Description>

--- a/src/Cake.Issues.InspectCode/Cake.Issues.InspectCode.csproj
+++ b/src/Cake.Issues.InspectCode/Cake.Issues.InspectCode.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Product>Cake.Issues</Product>
     <Description>JetBrains Inspect Code support for the Cake.Issues Addin for Cake Build Automation System</Description>
     <Authors>BBT Software AG</Authors>


### PR DESCRIPTION
Multi-Target .NET Core 3.1, 5, & 6 to follow best-practices for Cake 2.0.

Fixes #189