### PR TITLE
Use PowerShell instead of Cake task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,10 +18,5 @@ jobs:
     inputs:
       key: '"$(Agent.OS)" | recipe.cake'
       path: 'tools'
-  - task: Cake@2
-    inputs:
-      script: 'recipe.cake'
-      target: 'CI'
-      verbosity: 'Normal'
-      Bootstrap: true
-      Version: '0.38.5'
+  - powershell: ./build.ps1
+    displayName: 'Build'


### PR DESCRIPTION
Use standard PowerShell task instead of Cake task, since Cake task doesn't bring any advantages in this case (and has been deprecated)